### PR TITLE
Migrate from pybind11 to nanobind for Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
-find_package(pybind11 CONFIG REQUIRED)
+find_package(Python 3.12 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(nanobind CONFIG REQUIRED)
 
 FetchContent_Declare(
     eigen
@@ -26,7 +27,7 @@ find_package(BLAS QUIET)
 
 # --- Target ---
 
-pybind11_add_module(hypergraph src/Module.cpp)
+nanobind_add_module(hypergraph src/Module.cpp)
 
 target_include_directories(hypergraph PRIVATE
     "${CMAKE_SOURCE_DIR}/include"

--- a/include/hypergraph/hypergraph.h
+++ b/include/hypergraph/hypergraph.h
@@ -200,16 +200,16 @@ public: // python
     template <typename TModule>
     static void register_python(TModule& m)
     {
-        using namespace pybind11::literals;
-        namespace py = pybind11;
+        using namespace nanobind::literals;
+        namespace nb = nanobind;
 
         const std::string name = "Variable";
 
-        py::class_<Type>(m, name.c_str())
+        nb::class_<Type>(m, name.c_str())
             // properties
-            .def_property_readonly("value", &Type::value)
+            .def_prop_ro("value", &Type::value)
             // read-only properties
-            .def_property_readonly("_id", &Type::id)
+            .def_prop_ro("_id", &Type::id)
             // methods
             .def("__abs__", [](const Type& x) { return hypergraph::abs(x); })
             .def("__pow__", [](const Type& x, const double a) { return hypergraph::pow(x, a); })
@@ -237,41 +237,41 @@ public: // python
             .def("softplus", [](const Type& x) { return hypergraph::softplus(x); })
             .def("__pow__", [](const Type& x, const Type& y) { return hypergraph::pow(x, y); })
             // operators
-            .def(py::self == py::self)
-            .def(py::self != py::self)
-            .def(py::self < py::self)
-            .def(py::self > py::self)
-            .def(py::self <= py::self)
-            .def(py::self >= py::self)
-            .def(py::self == double())
-            .def(py::self != double())
-            .def(py::self < double())
-            .def(py::self > double())
-            .def(py::self <= double())
-            .def(py::self >= double())
-            .def(double() == py::self)
-            .def(double() != py::self)
-            .def(double() < py::self)
-            .def(double() > py::self)
-            .def(double() <= py::self)
-            .def(double() >= py::self)
-            .def(-py::self)
-            .def(py::self + py::self)
-            .def(py::self + double())
-            .def(double() + py::self)
-            .def(py::self += py::self)
-            .def(py::self - py::self)
-            .def(py::self - double())
-            .def(double() - py::self)
-            .def(py::self -= py::self)
-            .def(py::self * py::self)
-            .def(py::self * double())
-            .def(double() * py::self)
-            .def(py::self *= py::self)
-            .def(py::self / py::self)
-            .def(py::self / double())
-            .def(double() / py::self)
-            .def(py::self /= py::self);
+            .def(nb::self == nb::self)
+            .def(nb::self != nb::self)
+            .def(nb::self < nb::self)
+            .def(nb::self > nb::self)
+            .def(nb::self <= nb::self)
+            .def(nb::self >= nb::self)
+            .def(nb::self == double())
+            .def(nb::self != double())
+            .def(nb::self < double())
+            .def(nb::self > double())
+            .def(nb::self <= double())
+            .def(nb::self >= double())
+            .def(double() == nb::self)
+            .def(double() != nb::self)
+            .def(double() < nb::self)
+            .def(double() > nb::self)
+            .def(double() <= nb::self)
+            .def(double() >= nb::self)
+            .def(-nb::self)
+            .def(nb::self + nb::self)
+            .def(nb::self + double())
+            .def(double() + nb::self)
+            .def(nb::self += nb::self)
+            .def(nb::self - nb::self)
+            .def(nb::self - double())
+            .def(double() - nb::self)
+            .def(nb::self -= nb::self)
+            .def(nb::self * nb::self)
+            .def(nb::self * double())
+            .def(double() * nb::self)
+            .def(nb::self *= nb::self)
+            .def(nb::self / nb::self)
+            .def(nb::self / double())
+            .def(double() / nb::self)
+            .def(nb::self /= nb::self);
     }
 };
 
@@ -656,22 +656,22 @@ public: // python
     template <typename TModule>
     static void register_python(TModule& m)
     {
-        using namespace pybind11::literals;
-        namespace py = pybind11;
+        using namespace nanobind::literals;
+        namespace nb = nanobind;
 
         const std::string name = "HyperGraph";
 
-        py::class_<Type>(m, name.c_str())
+        nb::class_<Type>(m, name.c_str())
             // constructors
-            .def(py::init<>())
+            .def(nb::init<>())
             // methods
             .def("new_variable", &Type::new_variable, "value"_a)
             .def("new_variables", &Type::new_variables, "values"_a)
             .def("compute", &Type::compute, "expression"_a)
-            .def("g", py::overload_cast<>(&Type::g, py::const_))
-            .def("g", py::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&Type::g, py::const_), "out"_a)
-            .def("h", py::overload_cast<const bool>(&Type::h, py::const_), "full"_a = false)
-            .def("h", py::overload_cast<Eigen::Ref<Eigen::MatrixXd>, const bool>(&Type::h, py::const_), "out"_a, "full"_a = false);
+            .def("g", nb::overload_cast<>(&Type::g, nb::const_))
+            .def("g", nb::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&Type::g, nb::const_), "out"_a)
+            .def("h", nb::overload_cast<const bool>(&Type::h, nb::const_), "full"_a = false)
+            .def("h", nb::overload_cast<Eigen::Ref<Eigen::MatrixXd>, const bool>(&Type::h, nb::const_), "out"_a, "full"_a = false);
     }
 };
 

--- a/include/hypergraph/hypergraph.h
+++ b/include/hypergraph/hypergraph.h
@@ -9,12 +9,14 @@
 
 #pragma once
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <Eigen/Core>
 
 #include <tsl/robin_map.h>
 
 #include <algorithm>
-#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.13"]
+requires = ["scikit-build-core>=0.12.2", "nanobind>=2.12.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -1,12 +1,12 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/eigen/dense.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 #include <hypergraph/hypergraph.h>
 
-PYBIND11_MODULE(hypergraph, m) {
+NB_MODULE(hypergraph, m) {
     m.doc() = "HyperJet by Thomas Oberbichler";
     m.attr("__author__") = "Thomas Oberbichler";
     m.attr("__copyright__") = "Copyright (c) 2019, Thomas Oberbichler";
@@ -14,8 +14,8 @@ PYBIND11_MODULE(hypergraph, m) {
     m.attr("__email__") = "thomas.oberbichler@gmail.com";
     m.attr("__status__") = "Development";
 
-    namespace py = pybind11;
-    using namespace pybind11::literals;
+    namespace nb = nanobind;
+    using namespace nanobind::literals;
 
     hypergraph::HyperGraph<double>::register_python(m);
     hypergraph::Variable<double>::register_python(m);


### PR DESCRIPTION
Transition the Python bindings from pybind11 to nanobind, updating the necessary files and configurations to support this change. This migration enhances performance and compatibility with newer Python features.